### PR TITLE
Add temp-dir override for #diff, support for creating .cbmeta with #init and #target

### DIFF
--- a/defs.go
+++ b/defs.go
@@ -62,6 +62,7 @@ var (
 	AllPortals                 bool
 	AllPlugins                 bool
 	AllAdaptors                bool
+	TempDir				   string
 )
 
 var (

--- a/diff.go
+++ b/diff.go
@@ -84,6 +84,7 @@ func init() {
 	myDiffCommand.flags.StringVar(&RoleName, "role", "", "Name of role to diff")
 	myDiffCommand.flags.StringVar(&TriggerName, "trigger", "", "Name of trigger to diff")
 	myDiffCommand.flags.StringVar(&TimerName, "timer", "", "Name of timer to diff")
+	myDiffCommand.flags.StringVar(&TempDir, "temp-dir", "", "Temporary dir to place diff files")
 	AddCommand("diff", myDiffCommand)
 }
 
@@ -244,6 +245,10 @@ func diffCodeAndMeta(sys *System_meta, client *cb.DevClient, thangType, thangNam
 	myPid := os.Getpid()
 
 	tempDir := os.TempDir()
+	if TempDir != "" {
+		tempDir = TempDir
+	}
+	fmt.Println("Using Temp Dir: " + tempDir)
 
 	localFile := fmt.Sprintf("%s%d-local.js", tempDir, myPid)
 	remoteFile := fmt.Sprintf("%s%d-remote.js", tempDir, myPid)

--- a/init.go
+++ b/init.go
@@ -58,7 +58,6 @@ func reallyInit(cli *cb.DevClient, sysKey string) error {
 	}
 
 	if IsInRepo() {
-			fmt.Println("Setting up shop right here")
 			SetRootDir(".")
 	} else {
 		SetRootDir(strings.Replace(sysMeta.Name, " ", "_", -1))

--- a/init.go
+++ b/init.go
@@ -31,7 +31,7 @@ func init() {
 		usage:           usage,
 		needsAuth:       true,
 		mustBeInRepo:    false,
-		mustNotBeInRepo: true,
+		mustNotBeInRepo: false,
 		run:             doInit,
 		example:		 example,
 	}
@@ -57,9 +57,14 @@ func reallyInit(cli *cb.DevClient, sysKey string) error {
 		return err
 	}
 
-	SetRootDir(strings.Replace(sysMeta.Name, " ", "_", -1))
-	if err := setupDirectoryStructure(sysMeta); err != nil {
-		return err
+	if IsInRepo() {
+			fmt.Println("Setting up shop right here")
+			SetRootDir(".")
+	} else {
+		SetRootDir(strings.Replace(sysMeta.Name, " ", "_", -1))
+		if err := setupDirectoryStructure(sysMeta); err != nil {
+			return err
+		}
 	}
 	storeMeta(sysMeta)
 

--- a/newAuth.go
+++ b/newAuth.go
@@ -96,12 +96,11 @@ func GoToRepoRootDir() error {
 			os.Chdir(whereIReallyAm) //  go back in case this err is ignored
 			return fmt.Errorf(SpecialNoCBMetaError)
 		}
-		if MetaInfo, err = getDict(".cbmeta"); err != nil {
-			if err = os.Chdir(".."); err != nil {
-				return fmt.Errorf("Error changing directory: %s", err.Error())
-			}
-		} else {
+		if IsInRepo() {
+			// Exit
 			return nil
+		} else if err = os.Chdir(".."); err != nil {
+				return fmt.Errorf("Error changing directory: %s", err.Error())
 		}
 	}
 }

--- a/utils.go
+++ b/utils.go
@@ -315,3 +315,23 @@ func copyDir(src string, dst string) (err error) {
 
 	return
 }
+
+func IsInRepo() bool {
+	return FoundSystemDotJSON()
+}
+
+func FoundSystemDotJSON() bool {
+	if _, err := getDict("system.json"); err == nil {
+			return true
+	}
+	return false
+
+}
+
+func FoundCBMeta() bool {
+	if _, err := getDict(".cbmeta"); err == nil {
+			return true
+	}
+	return false
+
+}


### PR DESCRIPTION
Added Features:
DESK-206 - Diff needs override for users without access to the machine's tmp folder
CBCOMM-344 - Create .cbmeta with #init, #target
