### PR TITLE
update default user columns so that we don't try to create/delete def…

### DIFF
--- a/defs.go
+++ b/defs.go
@@ -90,7 +90,7 @@ var (
 )
 
 var (
-	DefaultUserColumns       = []string{"user_id", "creation_date", "email"}
+	DefaultUserColumns       = []string{"user_id", "creation_date", "email", "cb_service_account", "cb_ttl_override", "cb_token"}
 	DefaultEdgeColumns       = []string{"edge_key", "novi_system_key", "system_key", "system_secret", "token", "name", "description", "location", "mac_address", "public_addr", "public_port", "local_addr", "local_port", "broker_port", "broker_tls_port", "broker_ws_port", "broker_wss_port", "broker_auth_port", "broker_ws_auth_port", "first_talked", "last_talked", "communication_style", "last_seen_version", "policy_name", "resolver_func", "sync_edge_tables", "last_seen_architecture", "last_seen_os"}
 	DefaultDeviceColumns     = []string{"device_key", "name", "system_key", "type", "state", "description", "enabled", "allow_key_auth", "active_key", "keys", "allow_certificate_auth", "certificate", "created_date", "last_active_date", "salt"}
 	DefaultCollectionColumns = []string{"item_id"}

--- a/pull.go
+++ b/pull.go
@@ -48,6 +48,7 @@ func init() {
 	pullCommand.flags.BoolVar(&AllUsers, "all-users", false, "pull all users from system")
 	pullCommand.flags.BoolVar(&UserSchema, "userschema", false, "pull user table schema")
 	pullCommand.flags.BoolVar(&DeviceSchema, "deviceschema", false, "pull device table schema")
+	pullCommand.flags.BoolVar(&EdgeSchema, "edgeschema", false, "pull edges table schema")
 	pullCommand.flags.BoolVar(&AllAssets, "all", false, "pull all assets from system")
 	pullCommand.flags.BoolVar(&AllTriggers, "all-triggers", false, "pull all triggers from system")
 	pullCommand.flags.BoolVar(&AllTimers, "all-timers", false, "pull all timers from system")

--- a/push.go
+++ b/push.go
@@ -398,9 +398,10 @@ func pushAllEdges(systemInfo *System_meta, client *cb.DevClient) error {
 		return err
 	}
 	for _, edge := range edges {
-		fmt.Printf("Pushing edge %+s\n", edge["name"].(string))
+		edgeName := edge["name"].(string) // storing this here since updateEdge deletes "name" from the map
+		fmt.Printf("Pushing edge %+s\n", edgeName)
 		if err := updateEdge(systemInfo.Key, edge, client); err != nil {
-			return fmt.Errorf("Error updating edge '%s': %s\n", edge["name"].(string), err.Error())
+			return fmt.Errorf("Error updating edge '%s': %s\n", edgeName, err.Error())
 		}
 	}
 	return nil
@@ -1362,7 +1363,7 @@ func getMap(val interface{}) map[string]interface{} {
 }
 
 func updateUser(meta *System_meta, user map[string]interface{}, client *cb.DevClient) error {
-
+	delete(user, "cb_token")
 	if email, ok := user["email"].(string); !ok {
 		return fmt.Errorf("Missing user email %+v", user)
 	} else {


### PR DESCRIPTION
…ault user columns when pushing schema; add pull -edgeschema; modify pushAllEdges so that it stores a reference to the edge name in order to return an error message instead of panicking; delete cb_token when updating user so backend doesn't complain