### PR TITLE
Fix file and edge errors

### DIFF
--- a/push.go
+++ b/push.go
@@ -2057,7 +2057,15 @@ func updateEdge(systemKey string, edge map[string]interface{}, client *cb.DevCli
 	for columnName, value := range edge {
 		switch strings.ToLower(columnName) {
 		case "system_key", "system_secret", "token", "description", "location", "mac_address", "policy_name", "resolver_func", "sync_edge_tables", "last_seen_version":
-			originalColumns[columnName] = value
+
+			//We need to make sure there are valid values in the JSON to prevent an error when creating or updating edges:
+			//
+			//[[message:Create Edge: Bad type for key 'resolver_func'] statusCode:500]
+			if value == nil || value == "null" {
+				originalColumns[columnName] = ""
+			} else {
+				originalColumns[columnName] = value
+			}
 			break
 		default:
 			customColumns[columnName] = value
@@ -2547,7 +2555,15 @@ func createEdge(systemKey, name string, edge map[string]interface{}, client *cb.
 	for columnName, value := range edge {
 		switch strings.ToLower(columnName) {
 		case "system_key", "system_secret", "token", "description", "location", "mac_address", "policy_name", "resolver_func", "sync_edge_tables", "last_seen_version":
-			originalColumns[columnName] = value
+			//We need to make sure there are valid values in the JSON to prevent an error when creating or updating edges:
+			//
+			//[[message:Create Edge: Bad type for key 'resolver_func'] statusCode:500]
+			if value == nil || value == "null" {
+				originalColumns[columnName] = ""
+			} else {
+				originalColumns[columnName] = value
+			}
+			break
 		default:
 			if value != nil {
 				customColumns[columnName] = value


### PR DESCRIPTION
Fixes the following errors:

**Bucket set files**
- "panic: interface conversion: interface {} is nil, not string" when fileMeta bucketSetName, bucketName, or RelativeName are blank.
- "[ERROR] Failed to pull all bucket set files. map[error:map[detail:storage: object doesn't exist id:5a65c441-e7f1-47bc-8e07-753ea81dc9e2 line:clearblade/bucket_sets/api.go:171 message:storage: object doesn't exist] statusCode:500]" when fileMeta.size = 0 (folders/directories)

**Edge update/create**
- "message:Create Edge: Bad type for key 'resolver_func'] statusCode:500]" when string fields in JSON structure are set to null.

