### PR TITLE
AS-3633-cb-cli-diff

### DIFF
--- a/defs.go
+++ b/defs.go
@@ -96,6 +96,7 @@ var (
 	AutoApprove                bool
 	TempDir                    string
 	SkipUpdateMapNameToIdFiles bool
+	Path                       string
 )
 
 var (

--- a/fs.go
+++ b/fs.go
@@ -1519,3 +1519,20 @@ func storeDataInJSONFile(data map[string]interface{}, path string, fileName stri
 
 	return nil;
 }
+
+func readDataFromJSONDiffFile(filename string) map[string][]string {
+	jsonStr, err := ioutil.ReadFile(filename)
+	if err != nil {
+		fmt.Println("Error reading the json file ", err);
+	}
+
+	parsed := make(map[string][]string)
+
+	err = json.Unmarshal(jsonStr, &parsed)
+
+	if err != nil {
+		fmt.Println("error unmarshalling ", err)
+	}
+
+	return parsed;
+}

--- a/fs.go
+++ b/fs.go
@@ -1497,3 +1497,25 @@ func fileExists(name string) bool {
 	}
 	return true
 }
+
+func storeDataInJSONFile(data map[string]interface{}, path string, fileName string) error {
+	marshalled, err := json.MarshalIndent(data, "", "  ");
+
+	if err != nil {
+		fmt.Println("Error marshalling data ", err);
+		return err;
+	}
+
+	relativePath := ".";
+
+	if len(path) > 0 {
+		relativePath = path;
+	}
+
+	if err = ioutil.WriteFile(relativePath+"/"+fileName, marshalled, 0666); err != nil {
+		fmt.Println("Could not write to json file");
+		return err;
+	}
+
+	return nil;
+}

--- a/generateDiff.go
+++ b/generateDiff.go
@@ -1,0 +1,113 @@
+package cblib
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	cb "github.com/clearblade/Go-SDK"
+)
+
+func init() {
+	usage :=
+		`
+	Generates a diff between the code services and libraries present locally and in the system
+	`
+
+	example :=
+		`
+	  cb-cli diff # generate a diff file at the current path
+		cb-cli diff -path='./diff/' # generate a diff file inside the diff folder
+		`
+	generateDiffCommand := &SubCommand{
+		name:      "diff",
+		usage:     usage,
+		needsAuth: true,
+		run:       doGenerateDiff,
+		example:   example,
+	}
+	
+	generateDiffCommand.flags.StringVar(&Path, "path", "", "Path where diff file will be created")
+	AddCommand("diff", generateDiffCommand)
+}
+
+func doGenerateDiff(cmd *SubCommand, client *cb.DevClient, args ...string) error {
+	systemInfo, err := getSysMeta()
+	if err != nil {
+		return err;
+	}
+
+	client, err = checkIfTokenHasExpired(client, systemInfo.Key);
+	if err != nil {
+		return fmt.Errorf("Re-auth failed: %s\n", err)
+	}
+
+	logInfo("Diffing libraries:");
+	diffLibraries, err := getDiffEntity(systemInfo.Key, "libraries", client);
+
+	if err != nil {
+		return err;
+	}
+
+	logInfo("Diffing services:");
+	diffServices, err := getDiffEntity(systemInfo.Key, "services", client);
+
+	if err != nil {
+		return err;
+	}
+
+	dataMap := make(map[string]interface{});
+	dataMap["services"] = diffServices;
+	dataMap["libraries"] = diffLibraries;
+
+	err = storeDataInJSONFile(dataMap, Path, "diff.json");
+
+	if err != nil {
+		return err
+	}
+
+	logInfo("Created a diff.json file");
+	return nil;
+}
+
+func getDiffEntity(systemKey string, entityType string, client *cb.DevClient) ([]string, error) {
+	diffEntities := []string{}
+
+	rootPath := "./code/" + entityType;
+
+	entities, err := ioutil.ReadDir(rootPath);
+
+	if err != nil {
+		fmt.Println("error reading directory ", err);
+		return  nil,err;
+	}
+
+	for _, entity := range entities {
+		fmt.Print(entity.Name() + " ");
+		entityPath := rootPath+"/"+entity.Name()+"/"+entity.Name()
+
+		localEntityCode, err := ioutil.ReadFile(entityPath+".js");
+		if err != nil {
+			return nil,err;
+		}
+
+		var remoteEntityCode map[string]interface{}
+
+		if(entityType == "libraries") {
+			remoteEntityCode, err = pullLibrary(systemKey, entity.Name(), client)
+		} else {
+			remoteEntityCode, err = pullService(systemKey, entity.Name(), client)
+		}
+
+		if err != nil {
+			return nil, err;
+		}
+
+		if string(localEntityCode) != remoteEntityCode["code"] {
+			diffEntities = append(diffEntities, entity.Name())
+		}
+
+	}
+	fmt.Printf("\n")
+
+	return diffEntities, nil;
+}


### PR DESCRIPTION
### Add `diff` command

This command generates a `diff.json` file that contains the code services and libraries that have been changed (or added) locally. This diff file can then be used to push only these code services and libraries to the system using the `cb-cli push -diff=${path/to/diff.json}` command.