### PR TITLE
Keep email if trigger event is mqtt connect/disconnect

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -487,11 +487,27 @@ func replaceUserIdWithEmailInTriggerKeyValuePairs(trig map[string]interface{}, u
 }
 
 func isTriggerForSpecificUser(trig map[string]interface{}) (string, map[string]interface{}, bool) {
-	if kv, ok := trig["key_value_pairs"]; ok {
+	def, ok := trig["event_definition"].(map[string]interface{})
+	if !ok {
+		return "", nil, false
+	}
+
+	defName, ok := def["def_name"].(string)
+	if !ok {
+		return "", nil, false
+	}
+
+	if defName == "MQTTUserConnected" || defName == "MQTTUserDisconnected" {
+		return "", nil, false
+	}
+
+	kv, ok := trig["key_value_pairs"]
+	if ok {
 		if userEmail, ok := kv.(map[string]interface{})["email"]; ok {
 			return userEmail.(string), kv.(map[string]interface{}), ok
 		}
 	}
+
 	return "", nil, false
 }
 


### PR DESCRIPTION
When using cbcli we convert the `userid` field to `email` on triggers for better portability when pulling to the file system.

When pushing, we do the opposite, converting the `email` back to `userid`. We do this blindly if the `email` key exists in `key_value_pairs`. We were doing this even for MQTT event triggers, which expect the `email` field to exist, not `userid`. 

I added some logic here to not do the conversion in this case.