### PR TITLE
Improve role perm conversion

### DIFF
--- a/maputil/maputil.go
+++ b/maputil/maputil.go
@@ -2,7 +2,6 @@ package maputil
 
 import (
 	"fmt"
-	"os"
 )
 
 // --------------------------------
@@ -153,13 +152,11 @@ func GetASliceOfMaps(val interface{}) ([]map[string]interface{}, error) {
 	}
 }
 
-func GetMap(val interface{}) map[string]interface{} {
+func GetMap(val interface{}) (map[string]interface{}, error) {
 	switch val.(type) {
 	case map[string]interface{}:
-		return val.(map[string]interface{})
+		return val.(map[string]interface{}), nil
 	default:
-		fmt.Printf("permissions type must be a map, not %T\n", val)
-		os.Exit(1)
+		return nil, fmt.Errorf("permissions type must be a map, not %T\n", val)
 	}
-	return map[string]interface{}{}
 }

--- a/models/roles/roles.go
+++ b/models/roles/roles.go
@@ -2,7 +2,6 @@ package roles
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/clearblade/cblib/diff"
 	"github.com/clearblade/cblib/listutil"
@@ -18,8 +17,12 @@ func PackageRoleForUpdate(roleID string, role map[string]interface{}, fetcher Co
 	if !ok {
 		return map[string]interface{}{}, fmt.Errorf("permissions for role do not exist or is not a map")
 	}
-	convertedPermissions := ConvertPermissionsStructure(permissions, fetcher)
-	return map[string]interface{}{"ID": roleID, "Permissions": convertedPermissions}, nil
+
+	if convertedPermissions, err := ConvertPermissionsStructure(permissions, fetcher); err != nil {
+		return nil, err
+	} else {
+		return map[string]interface{}{"ID": roleID, "Permissions": convertedPermissions}, nil
+	}
 }
 
 // The roles structure we get back when we retrieve roles is different from
@@ -27,214 +30,214 @@ func PackageRoleForUpdate(roleID string, role map[string]interface{}, fetcher Co
 // conversion function. -swm
 //
 // THis is a gigantic cluster. We need to fix and learn from this. -swm
-func ConvertPermissionsStructure(in map[string]interface{}, fetcher CollectionIdFetcher) map[string]interface{} {
+func ConvertPermissionsStructure(in map[string]interface{}, fetcher CollectionIdFetcher) (map[string]interface{}, error) {
 	out := map[string]interface{}{}
 	for key, valIF := range in {
+		if valIF == nil {
+			continue
+		}
+
 		switch key {
 		case "CodeServices":
-			if valIF != nil {
-				services, err := maputil.GetASliceOfMaps(valIF)
-				if err != nil {
-					fmt.Printf("Bad format for services permissions, not a slice of maps: %T\n", valIF)
-					os.Exit(1)
-				}
-				svcs := make([]map[string]interface{}, len(services))
-				for idx, mapVal := range services {
-					svcs[idx] = map[string]interface{}{
-						"itemInfo":    map[string]interface{}{"name": mapVal["Name"]},
-						"permissions": mapVal["Level"],
-					}
-				}
-				out["services"] = removeDuplicatePermissions(svcs, "name")
+			services, err := maputil.GetASliceOfMaps(valIF)
+			if err != nil {
+				return nil, fmt.Errorf("bad format for services permissions, not a slice of maps: %T\n", valIF)
 			}
+			svcs := make([]map[string]interface{}, len(services))
+			for idx, mapVal := range services {
+				svcs[idx] = map[string]interface{}{
+					"itemInfo":    map[string]interface{}{"name": mapVal["Name"]},
+					"permissions": mapVal["Level"],
+				}
+			}
+			out["services"] = removeDuplicatePermissions(svcs, "name")
 		case "Collections":
-			if valIF != nil {
-				collections, err := maputil.GetASliceOfMaps(valIF)
-				if err != nil {
-					fmt.Printf("Bad format for collections permissions, not a slice of maps: %T\n", valIF)
-					os.Exit(1)
-				}
-				cols := make([]map[string]interface{}, 0)
-				for _, mapVal := range collections {
-					collName := mapVal["Name"].(string)
-					id, err := fetcher.GetCollectionIdByName(collName)
-					if err != nil {
-						fmt.Printf("Skipping permissions for collection '%s'; Error is - %s", collName, err.Error())
-						continue
-					}
-					cols = append(cols, map[string]interface{}{
-						"itemInfo":    map[string]interface{}{"id": id, "name": collName},
-						"permissions": mapVal["Level"],
-					})
-				}
-				out["collections"] = removeDuplicatePermissions(cols, "id")
+			collections, err := maputil.GetASliceOfMaps(valIF)
+			if err != nil {
+				return nil, fmt.Errorf("bad format for collections permissions, not a slice of maps: %T\n", valIF)
 			}
+			cols := make([]map[string]interface{}, 0)
+			for _, mapVal := range collections {
+				collName := mapVal["Name"].(string)
+				id, err := fetcher.GetCollectionIdByName(collName)
+				if err != nil {
+					return nil, fmt.Errorf("could not get id for collection named %q: %s", collName, err)
+				}
+				cols = append(cols, map[string]interface{}{
+					"itemInfo":    map[string]interface{}{"id": id, "name": collName},
+					"permissions": mapVal["Level"],
+				})
+			}
+			out["collections"] = removeDuplicatePermissions(cols, "id")
 		case "DevicesList":
-			if valIF != nil {
-				val := maputil.GetMap(valIF)
+			if val, err := maputil.GetMap(valIF); err != nil {
+				return nil, err
+			} else {
 				out["devices"] = map[string]interface{}{"permissions": val["Level"]}
 			}
 		case "MsgHistory":
-			if valIF != nil {
-				val := maputil.GetMap(valIF)
+			if val, err := maputil.GetMap(valIF); err != nil {
+				return nil, err
+			} else {
 				out["msgHistory"] = map[string]interface{}{"permissions": val["Level"]}
 			}
 		case "SystemServices":
-			if valIF != nil {
-				val := maputil.GetMap(valIF)
+			if val, err := maputil.GetMap(valIF); err != nil {
+				return nil, err
+			} else {
 				out["system_services"] = map[string]interface{}{"permissions": val["Level"]}
 			}
 		case "Portals":
-			if valIF != nil {
-				portals, err := maputil.GetASliceOfMaps(valIF)
-				if err != nil {
-					fmt.Printf("Bad format for portals permissions, not a slice of maps: %T\n", valIF)
-					os.Exit(1)
-				}
-				ptls := make([]map[string]interface{}, len(portals))
-				for idx, mapVal := range portals {
-					ptls[idx] = map[string]interface{}{
-						"itemInfo":    map[string]interface{}{"name": mapVal["Name"]},
-						"permissions": mapVal["Level"],
-					}
-				}
-				out["portals"] = removeDuplicatePermissions(ptls, "name")
+			portals, err := maputil.GetASliceOfMaps(valIF)
+			if err != nil {
+				return nil, fmt.Errorf("bad format for portals permissions, not a slice of maps: %T\n", valIF)
 			}
+			ptls := make([]map[string]interface{}, len(portals))
+			for idx, mapVal := range portals {
+				ptls[idx] = map[string]interface{}{
+					"itemInfo":    map[string]interface{}{"name": mapVal["Name"]},
+					"permissions": mapVal["Level"],
+				}
+			}
+			out["portals"] = removeDuplicatePermissions(ptls, "name")
 		case "ExternalDatabases":
-			if valIF != nil {
-				externalDatabases, err := maputil.GetASliceOfMaps(valIF)
-				if err != nil {
-					fmt.Printf("Bad format for externalDatabases permissions, not a slice of maps: %T\n", valIF)
-					os.Exit(1)
-				}
-				extDbs := make([]map[string]interface{}, len(externalDatabases))
-				for idx, mapVal := range externalDatabases {
-					extDbs[idx] = map[string]interface{}{
-						"itemInfo":    map[string]interface{}{"name": mapVal["Name"]},
-						"permissions": mapVal["Level"],
-					}
-				}
-				out["externaldatabases"] = removeDuplicatePermissions(extDbs, "name")
+			externalDatabases, err := maputil.GetASliceOfMaps(valIF)
+			if err != nil {
+				return nil, fmt.Errorf("bad format for externalDatabases permissions, not a slice of maps: %T\n", valIF)
 			}
+			extDbs := make([]map[string]interface{}, len(externalDatabases))
+			for idx, mapVal := range externalDatabases {
+				extDbs[idx] = map[string]interface{}{
+					"itemInfo":    map[string]interface{}{"name": mapVal["Name"]},
+					"permissions": mapVal["Level"],
+				}
+			}
+			out["externaldatabases"] = removeDuplicatePermissions(extDbs, "name")
 		case "ServiceCaches":
-			if valIF != nil {
-				serviceCaches, err := maputil.GetASliceOfMaps(valIF)
-				if err != nil {
-					fmt.Printf("Bad format for serviceCaches permissions, not a slice of maps: %T\n", valIF)
-					os.Exit(1)
-				}
-				svcCaches := make([]map[string]interface{}, len(serviceCaches))
-				for idx, mapVal := range serviceCaches {
-					svcCaches[idx] = map[string]interface{}{
-						"itemInfo":    map[string]interface{}{"name": mapVal["Name"]},
-						"permissions": mapVal["Level"],
-					}
-				}
-				out["servicecaches"] = removeDuplicatePermissions(svcCaches, "name")
+			serviceCaches, err := maputil.GetASliceOfMaps(valIF)
+			if err != nil {
+				return nil, fmt.Errorf("Bad format for serviceCaches permissions, not a slice of maps: %T\n", valIF)
 			}
+			svcCaches := make([]map[string]interface{}, len(serviceCaches))
+			for idx, mapVal := range serviceCaches {
+				svcCaches[idx] = map[string]interface{}{
+					"itemInfo":    map[string]interface{}{"name": mapVal["Name"]},
+					"permissions": mapVal["Level"],
+				}
+			}
+			out["servicecaches"] = removeDuplicatePermissions(svcCaches, "name")
 		case "Push":
-			if valIF != nil {
-				val := maputil.GetMap(valIF)
+			if val, err := maputil.GetMap(valIF); err != nil {
+				return nil, err
+			} else {
 				out["push"] = map[string]interface{}{"permissions": val["Level"]}
 			}
 		case "Topics":
-			if valIF != nil {
-				topics, err := maputil.GetASliceOfMaps(valIF)
-				if err != nil {
-					fmt.Printf("Bad format for topics permissions, not a slice of maps: %T\n", valIF)
-					os.Exit(1)
-				}
-				tpcs := make([]map[string]interface{}, len(topics))
-				for idx, mapVal := range topics {
-					tpcs[idx] = map[string]interface{}{
-						"itemInfo":    map[string]interface{}{"name": mapVal["Name"]},
-						"permissions": mapVal["Level"],
-					}
-				}
-				out["topics"] = tpcs
+			topics, err := maputil.GetASliceOfMaps(valIF)
+			if err != nil {
+				return nil, fmt.Errorf("Bad format for serviceCaches permissions, not a slice of maps: %T\n", valIF)
 			}
+			tpcs := make([]map[string]interface{}, len(topics))
+			for idx, mapVal := range topics {
+				tpcs[idx] = map[string]interface{}{
+					"itemInfo":    map[string]interface{}{"name": mapVal["Name"]},
+					"permissions": mapVal["Level"],
+				}
+			}
+			out["topics"] = tpcs
 		case "UsersList":
-			if valIF != nil {
-				val := maputil.GetMap(valIF)
+			if val, err := maputil.GetMap(valIF); err != nil {
+				return nil, err
+			} else {
 				out["users"] = map[string]interface{}{"permissions": val["Level"]}
 			}
 		case "EdgesList":
-			if valIF != nil {
-				val := maputil.GetMap(valIF)
+			if val, err := maputil.GetMap(valIF); err != nil {
+				return nil, err
+			} else {
 				out["edges"] = map[string]interface{}{"permissions": val["Level"]}
 			}
 
 		case "Triggers":
-			if valIF != nil {
-				val := maputil.GetMap(valIF)
+			if val, err := maputil.GetMap(valIF); err != nil {
+				return nil, err
+			} else {
 				out["triggers"] = map[string]interface{}{"permissions": val["Level"]}
 			}
 		case "Timers":
-			if valIF != nil {
-				val := maputil.GetMap(valIF)
+			if val, err := maputil.GetMap(valIF); err != nil {
+				return nil, err
+			} else {
 				out["timers"] = map[string]interface{}{"permissions": val["Level"]}
 			}
 		case "Deployments":
-			if valIF != nil {
-				val := maputil.GetMap(valIF)
+			if val, err := maputil.GetMap(valIF); err != nil {
+				return nil, err
+			} else {
 				out["deployments"] = map[string]interface{}{"permissions": val["Level"]}
 			}
 		case "Roles":
-			if valIF != nil {
-				val := maputil.GetMap(valIF)
+			if val, err := maputil.GetMap(valIF); err != nil {
+				return nil, err
+			} else {
 				out["roles"] = map[string]interface{}{"permissions": val["Level"]}
 			}
 		case "AllCollections":
-			if valIF != nil {
-				val := maputil.GetMap(valIF)
+			if val, err := maputil.GetMap(valIF); err != nil {
+				return nil, err
+			} else {
 				out["allcollections"] = map[string]interface{}{"permissions": val["Level"]}
 			}
 		case "AllServices":
-			if valIF != nil {
-				val := maputil.GetMap(valIF)
+			if val, err := maputil.GetMap(valIF); err != nil {
+				return nil, err
+			} else {
 				out["allservices"] = map[string]interface{}{"permissions": val["Level"]}
 			}
 		case "ManageUsers":
 			if valIF != nil {
-				val := maputil.GetMap(valIF)
-				out["manageusers"] = map[string]interface{}{"permissions": val["Level"]}
+				if val, err := maputil.GetMap(valIF); err != nil {
+					return nil, err
+				} else {
+					out["manageusers"] = map[string]interface{}{"permissions": val["Level"]}
+				}
 			}
 		case "AllExternalDatabases":
-			if valIF != nil {
-				val := maputil.GetMap(valIF)
+			if val, err := maputil.GetMap(valIF); err != nil {
+				return nil, err
+			} else {
 				out["allexternaldatabases"] = map[string]interface{}{"permissions": val["Level"]}
 			}
 		case "Files":
-			if valIF != nil {
-				files, err := maputil.GetASliceOfMaps(valIF)
-				if err != nil {
-					fmt.Printf("Bad format for files permissions, not a slice of maps: %T\n", valIF)
-					os.Exit(1)
-				}
-				theFiles := make([]map[string]interface{}, len(files))
-				for idx, mapVal := range files {
-					theFiles[idx] = map[string]interface{}{
-						"itemInfo":    map[string]interface{}{"name": mapVal["Name"]},
-						"permissions": mapVal["Level"],
-					}
-				}
-				out["files"] = removeDuplicatePermissions(theFiles, "name")
+			files, err := maputil.GetASliceOfMaps(valIF)
+			if err != nil {
+				return nil, fmt.Errorf("Bad format for serviceCaches permissions, not a slice of maps: %T\n", valIF)
 			}
+			theFiles := make([]map[string]interface{}, len(files))
+			for idx, mapVal := range files {
+				theFiles[idx] = map[string]interface{}{
+					"itemInfo":    map[string]interface{}{"name": mapVal["Name"]},
+					"permissions": mapVal["Level"],
+				}
+			}
+			out["files"] = removeDuplicatePermissions(theFiles, "name")
 		case "usersecrets":
-			if valIF != nil {
-				val := maputil.GetMap(valIF)
+			if val, err := maputil.GetMap(valIF); err != nil {
+				return nil, err
+			} else {
 				out["usersecrets"] = map[string]interface{}{"permissions": val["Level"]}
 			}
 		case "adapters":
-			if valIF != nil {
-				val := maputil.GetMap(valIF)
+			if val, err := maputil.GetMap(valIF); err != nil {
+				return nil, err
+			} else {
 				out["adapters"] = map[string]interface{}{"permissions": val["Level"]}
 			}
 		default:
 
 		}
 	}
-	return out
+	return out, nil
 }
 
 // it's possible that there are duplicate permissions


### PR DESCRIPTION
Changed this function to return an error instead of printing them out or calling `os.Exit` (since we use this in the backend).

Also removed an unnecessary level of nesting from the switch cases.