### PR TITLE
Allow psql types with modifiers

### DIFF
--- a/colutil/colutil.go
+++ b/colutil/colutil.go
@@ -71,73 +71,19 @@ func normalizeType(t string) string {
 		return "bool"
 	case "timestamp without time zone":
 		return "timestamp"
-	// PostgreSQL aliases without ClearBlade equivalents — normalized to canonical form
-	case "serial8":
-		return "bigserial"
-	case "varbit":
-		return "bit varying"
-	case "char":
-		return "character"
-	case "int2":
-		return "smallint"
-	case "decimal":
-		return "numeric"
-	case "serial2":
-		return "smallserial"
-	case "serial4":
-		return "serial"
-	case "timetz":
-		return "time with time zone"
-	case "timestamptz":
-		return "timestamp with time zone"
 	default:
 		return t
 	}
 }
 
-// isValidColumnType checks whether a type string is a recognized app type or PostgreSQL type.
-// This matches the PsqlType() function in the clearblade server (postgres/dbOps.go).
+// isValidColumnType checks whether a type string is a valid ClearBlade app type.
+// Only the 10 app types (string, int, bool, timestamp, float, bigint, double,
+// jsonb, blob, uuid) plus the internal types counter and autoincrement are accepted.
 func isValidColumnType(t string) bool {
-	t = typeModifierRe.ReplaceAllString(t, "")
 	switch t {
-	// App types
-	case "string", "int", "bigint", "float", "double", "blob", "uuid", "timestamp", "bool", "counter", "autoincrement":
-		return true
-	// PostgreSQL native types.
-	// Note: "bigint", "uuid", "timestamp", "bool", "int", and "float" are omitted here
-	// because they are already matched as app types above.
-	case "int8",
-		"bigserial", "serial8",
-		"bit", "bit varying", "varbit",
-		"boolean",
-		"box",
-		"bytea",
-		"character", "char", "character varying", "varchar",
-		"cidr",
-		"circle",
-		"date",
-		"double precision", "float8", "float4",
-		"inet",
-		"integer", "int4", "int2",
-		"interval",
-		"json", "jsonb",
-		"line", "lseg",
-		"macaddr", "macaddr8",
-		"money",
-		"numeric", "decimal",
-		"path",
-		"pg_lsn", "pg_snapshot",
-		"point", "polygon",
-		"real",
-		"smallint",
-		"smallserial", "serial2",
-		"serial", "serial4",
-		"text",
-		"time", "time without time zone", "time with time zone", "timetz",
-		"timestamp without time zone", "timestamp with time zone", "timestamptz",
-		"tsquery", "tsvector",
-		"txid_snapshot",
-		"xml":
+	case "string", "int", "bool", "timestamp", "float", "bigint", "double",
+		"jsonb", "blob", "uuid",
+		"counter", "autoincrement":
 		return true
 	default:
 		return false

--- a/colutil/colutil.go
+++ b/colutil/colutil.go
@@ -54,20 +54,42 @@ func isDefaultColumn(defaultColumns []string, colName string) bool {
 func normalizeType(t string) string {
 	t = typeModifierRe.ReplaceAllString(t, "")
 	switch t {
+	// PostgreSQL types with ClearBlade app type equivalents
 	case "character varying", "varchar", "text":
 		return "string"
-	case "integer":
+	case "integer", "int4":
 		return "int"
-	case "real":
+	case "int8":
+		return "bigint"
+	case "real", "float4":
 		return "float"
+	case "double precision", "float8":
+		return "double"
 	case "bytea":
 		return "blob"
 	case "boolean":
 		return "bool"
-	case "double precision":
-		return "double"
 	case "timestamp without time zone":
 		return "timestamp"
+	// PostgreSQL aliases without ClearBlade equivalents — normalized to canonical form
+	case "serial8":
+		return "bigserial"
+	case "varbit":
+		return "bit varying"
+	case "char":
+		return "character"
+	case "int2":
+		return "smallint"
+	case "decimal":
+		return "numeric"
+	case "serial2":
+		return "smallserial"
+	case "serial4":
+		return "serial"
+	case "timetz":
+		return "time with time zone"
+	case "timestamptz":
+		return "timestamp with time zone"
 	default:
 		return t
 	}

--- a/colutil/colutil.go
+++ b/colutil/colutil.go
@@ -2,14 +2,10 @@ package colutil
 
 import (
 	"fmt"
-	"regexp"
 
 	"github.com/clearblade/cblib/diff"
 	"github.com/clearblade/cblib/listutil"
 )
-
-// typeModifierRe matches PostgreSQL type modifiers like (128), (10,2), (6).
-var typeModifierRe = regexp.MustCompile(`\s*\([^)]*\)`)
 
 func GetDiffForColumnsWithDynamicListOfDefaultColumns(localSchemaInterfaces, backendSchemaInterfaces []map[string]interface{}) (*diff.UnsafeDiff[map[string]interface{}], error) {
 	if err := validateColumnTypes(localSchemaInterfaces); err != nil {
@@ -50,9 +46,8 @@ func isDefaultColumn(defaultColumns []string, colName string) bool {
 }
 
 // normalizeType maps PostgreSQL native type names to app-level type names.
-// This matches the Typed() function in the clearblade server (postgres/dbOps.go).
+// This matches the ClearBladeType() function in the clearblade server (postgres/dbOps.go).
 func normalizeType(t string) string {
-	t = typeModifierRe.ReplaceAllString(t, "")
 	switch t {
 	// PostgreSQL types with ClearBlade app type equivalents
 	case "character varying", "varchar", "text":

--- a/colutil/colutil.go
+++ b/colutil/colutil.go
@@ -2,10 +2,14 @@ package colutil
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/clearblade/cblib/diff"
 	"github.com/clearblade/cblib/listutil"
 )
+
+// typeModifierRe matches PostgreSQL type modifiers like (128), (10,2), (6).
+var typeModifierRe = regexp.MustCompile(`\s*\([^)]*\)`)
 
 func GetDiffForColumnsWithDynamicListOfDefaultColumns(localSchemaInterfaces, backendSchemaInterfaces []map[string]interface{}) (*diff.UnsafeDiff[map[string]interface{}], error) {
 	if err := validateColumnTypes(localSchemaInterfaces); err != nil {
@@ -48,6 +52,7 @@ func isDefaultColumn(defaultColumns []string, colName string) bool {
 // normalizeType maps PostgreSQL native type names to app-level type names.
 // This matches the Typed() function in the clearblade server (postgres/dbOps.go).
 func normalizeType(t string) string {
+	t = typeModifierRe.ReplaceAllString(t, "")
 	switch t {
 	case "character varying", "varchar", "text":
 		return "string"
@@ -71,6 +76,7 @@ func normalizeType(t string) string {
 // isValidColumnType checks whether a type string is a recognized app type or PostgreSQL type.
 // This matches the PsqlType() function in the clearblade server (postgres/dbOps.go).
 func isValidColumnType(t string) bool {
+	t = typeModifierRe.ReplaceAllString(t, "")
 	switch t {
 	// App types
 	case "string", "int", "bigint", "float", "double", "blob", "uuid", "timestamp", "bool", "counter", "autoincrement":

--- a/colutil/colutil_test.go
+++ b/colutil/colutil_test.go
@@ -150,24 +150,41 @@ func Test_NormalizeType(t *testing.T) {
 		input    string
 		expected string
 	}{
-		{"boolean", "bool"},
-		{"bool", "bool"},
-		{"integer", "int"},
-		{"int", "int"},
-		{"text", "string"},
+		// App types — pass through unchanged
 		{"string", "string"},
+		{"int", "int"},
+		{"bigint", "bigint"},
+		{"float", "float"},
+		{"double", "double"},
+		{"blob", "blob"},
+		{"bool", "bool"},
+		{"timestamp", "timestamp"},
+		{"uuid", "uuid"},
+		// PostgreSQL canonical types with ClearBlade equivalents
+		{"text", "string"},
 		{"character varying", "string"},
 		{"varchar", "string"},
+		{"integer", "int"},
 		{"real", "float"},
-		{"float", "float"},
 		{"double precision", "double"},
-		{"double", "double"},
 		{"bytea", "blob"},
-		{"blob", "blob"},
+		{"boolean", "bool"},
 		{"timestamp without time zone", "timestamp"},
-		{"timestamp", "timestamp"},
-		{"bigint", "bigint"},
-		{"uuid", "uuid"},
+		// Aliases that normalize to their ClearBlade app type equivalent
+		{"int4", "int"},
+		{"int8", "bigint"},
+		{"float4", "float"},
+		{"float8", "double"},
+		// Aliases that normalize to their canonical PostgreSQL form
+		{"serial8", "bigserial"},
+		{"varbit", "bit varying"},
+		{"char", "character"},
+		{"int2", "smallint"},
+		{"decimal", "numeric"},
+		{"serial2", "smallserial"},
+		{"serial4", "serial"},
+		{"timetz", "time with time zone"},
+		{"timestamptz", "timestamp with time zone"},
 	}
 
 	for _, tc := range tests {

--- a/colutil/colutil_test.go
+++ b/colutil/colutil_test.go
@@ -175,17 +175,7 @@ func Test_NormalizeType(t *testing.T) {
 		{"int8", "bigint"},
 		{"float4", "float"},
 		{"float8", "double"},
-		// Aliases that normalize to their canonical PostgreSQL form
-		{"serial8", "bigserial"},
-		{"varbit", "bit varying"},
-		{"char", "character"},
-		{"int2", "smallint"},
-		{"decimal", "numeric"},
-		{"serial2", "smallserial"},
-		{"serial4", "serial"},
-		{"timetz", "time with time zone"},
-		{"timestamptz", "timestamp with time zone"},
-	}
+		}
 
 	for _, tc := range tests {
 		result := normalizeType(tc.input)
@@ -197,41 +187,10 @@ func Test_NormalizeType(t *testing.T) {
 
 func Test_IsValidColumnType(t *testing.T) {
 	validTypes := []string{
-		// App types
-		"string", "int", "bigint", "float", "double", "blob", "uuid", "timestamp", "bool", "counter", "autoincrement",
-		// PostgreSQL native types
-		"int8",
-		"bigserial", "serial8",
-		"bit", "bit varying", "varbit",
-		"boolean",
-		"box",
-		"bytea",
-		"character", "char", "character varying", "varchar",
-		"cidr",
-		"circle",
-		"date",
-		"double precision", "float8", "float4",
-		"inet",
-		"integer", "int4", "int2",
-		"interval",
-		"json", "jsonb",
-		"line", "lseg",
-		"macaddr", "macaddr8",
-		"money",
-		"numeric", "decimal",
-		"path",
-		"pg_lsn", "pg_snapshot",
-		"point", "polygon",
-		"real",
-		"smallint",
-		"smallserial", "serial2",
-		"serial", "serial4",
-		"text",
-		"time", "time without time zone", "time with time zone", "timetz",
-		"timestamp without time zone", "timestamp with time zone", "timestamptz",
-		"tsquery", "tsvector",
-		"txid_snapshot",
-		"xml",
+		// The 10 ClearBlade app types
+		"string", "int", "bool", "timestamp", "float", "bigint", "double", "jsonb", "blob", "uuid",
+		// Internal types
+		"counter", "autoincrement",
 	}
 	for _, typ := range validTypes {
 		if !isValidColumnType(typ) {
@@ -239,7 +198,15 @@ func Test_IsValidColumnType(t *testing.T) {
 		}
 	}
 
-	invalidTypes := []string{"str", "bogus", "INT", "Bool", ""}
+	invalidTypes := []string{
+		// Nonsense
+		"str", "bogus", "INT", "Bool", "",
+		// PostgreSQL types — no longer valid as schema column types
+		"boolean", "text", "integer", "real", "double precision", "bytea",
+		"character varying", "varchar", "int4", "int8", "float4", "float8",
+		"timestamp without time zone", "smallint", "numeric", "json",
+		"bit", "date", "xml", "cidr", "timestamptz", "timestamp with time zone",
+	}
 	for _, typ := range invalidTypes {
 		if isValidColumnType(typ) {
 			t.Errorf("isValidColumnType(%q) = true, expected false", typ)
@@ -262,7 +229,7 @@ func Test_ValidateColumnTypes_AcceptsValid(t *testing.T) {
 	columns := []map[string]interface{}{
 		{"ColumnName": "col1", "ColumnType": "string"},
 		{"ColumnName": "col2", "ColumnType": "bool"},
-		{"ColumnName": "col3", "ColumnType": "boolean"},
+		{"ColumnName": "col3", "ColumnType": "jsonb"},
 	}
 	err := validateColumnTypes(columns)
 	if err != nil {
@@ -294,13 +261,13 @@ func Test_ColumnExists_NormalizesTypes(t *testing.T) {
 }
 
 func Test_DiffWithPsqlTypeAliases_NoFalseRemoval(t *testing.T) {
-	// Local schema uses PostgreSQL type "boolean", backend has app type "bool".
-	// These should be treated as the same column — no removal or addition.
+	// Local schema uses app type "bool"; backend (DB) has PostgreSQL type "boolean".
+	// normalizeType maps both to "bool" — no removal or addition.
 	local := []map[string]interface{}{
-		{"ColumnName": "active", "ColumnType": "boolean", "UserDefined": true},
+		{"ColumnName": "active", "ColumnType": "bool", "UserDefined": true},
 	}
 	backend := []map[string]interface{}{
-		{"ColumnName": "active", "ColumnType": "bool", "UserDefined": true},
+		{"ColumnName": "active", "ColumnType": "boolean", "UserDefined": true},
 	}
 	diff, err := GetDiffForColumnsWithDynamicListOfDefaultColumns(local, backend)
 	if err != nil {
@@ -314,21 +281,21 @@ func Test_DiffWithPsqlTypeAliases_NoFalseRemoval(t *testing.T) {
 	}
 }
 
-func Test_TypeModifiers_AcceptedAndNormalized(t *testing.T) {
-	// varchar(128) should be valid and match "string" on the backend
+func Test_TypeModifiers_BackendNormalized(t *testing.T) {
+	// The local schema uses app types (string, timestamp).
+	// The backend (DB) may return PostgreSQL types with modifiers.
+	// normalizeType strips the modifier and maps to the app type — no false removals.
 	local := []map[string]interface{}{
-		{"ColumnName": "name", "ColumnType": "varchar(128)", "UserDefined": true},
-		{"ColumnName": "score", "ColumnType": "numeric(10,2)", "UserDefined": true},
-		{"ColumnName": "created", "ColumnType": "timestamp(6) without time zone", "UserDefined": true},
+		{"ColumnName": "name", "ColumnType": "string", "UserDefined": true},
+		{"ColumnName": "created", "ColumnType": "timestamp", "UserDefined": true},
 	}
 	backend := []map[string]interface{}{
-		{"ColumnName": "name", "ColumnType": "string", "UserDefined": true},
-		{"ColumnName": "score", "ColumnType": "numeric", "UserDefined": true},
-		{"ColumnName": "created", "ColumnType": "timestamp", "UserDefined": true},
+		{"ColumnName": "name", "ColumnType": "varchar(128)", "UserDefined": true},
+		{"ColumnName": "created", "ColumnType": "timestamp(6) without time zone", "UserDefined": true},
 	}
 	diff, err := GetDiffForColumnsWithDynamicListOfDefaultColumns(local, backend)
 	if err != nil {
-		t.Fatalf("Unexpected error for types with modifiers: %s", err)
+		t.Fatalf("Unexpected error: %s", err)
 	}
 	if len(diff.Removed) != 0 {
 		t.Errorf("Expected 0 removals but got %d — type modifier caused false removal", len(diff.Removed))

--- a/colutil/colutil_test.go
+++ b/colutil/colutil_test.go
@@ -297,6 +297,30 @@ func Test_DiffWithPsqlTypeAliases_NoFalseRemoval(t *testing.T) {
 	}
 }
 
+func Test_TypeModifiers_AcceptedAndNormalized(t *testing.T) {
+	// varchar(128) should be valid and match "string" on the backend
+	local := []map[string]interface{}{
+		{"ColumnName": "name", "ColumnType": "varchar(128)", "UserDefined": true},
+		{"ColumnName": "score", "ColumnType": "numeric(10,2)", "UserDefined": true},
+		{"ColumnName": "created", "ColumnType": "timestamp(6) without time zone", "UserDefined": true},
+	}
+	backend := []map[string]interface{}{
+		{"ColumnName": "name", "ColumnType": "string", "UserDefined": true},
+		{"ColumnName": "score", "ColumnType": "numeric", "UserDefined": true},
+		{"ColumnName": "created", "ColumnType": "timestamp", "UserDefined": true},
+	}
+	diff, err := GetDiffForColumnsWithDynamicListOfDefaultColumns(local, backend)
+	if err != nil {
+		t.Fatalf("Unexpected error for types with modifiers: %s", err)
+	}
+	if len(diff.Removed) != 0 {
+		t.Errorf("Expected 0 removals but got %d — type modifier caused false removal", len(diff.Removed))
+	}
+	if len(diff.Added) != 0 {
+		t.Errorf("Expected 0 additions but got %d — type modifier caused false addition", len(diff.Added))
+	}
+}
+
 func Test_DiffWithInvalidType_ReturnsError(t *testing.T) {
 	local := []map[string]interface{}{
 		{"ColumnName": "bad_col", "ColumnType": "str", "UserDefined": true},

--- a/colutil/colutil_test.go
+++ b/colutil/colutil_test.go
@@ -281,10 +281,10 @@ func Test_DiffWithPsqlTypeAliases_NoFalseRemoval(t *testing.T) {
 	}
 }
 
-func Test_TypeModifiers_BackendNormalized(t *testing.T) {
-	// The local schema uses app types (string, timestamp).
-	// The backend (DB) may return PostgreSQL types with modifiers.
-	// normalizeType strips the modifier and maps to the app type — no false removals.
+func Test_TypeModifiers_BackendNotNormalized(t *testing.T) {
+	// A type modifier like varchar(128) or timestamp(6) means the schema was
+	// changed outside of ClearBlade. We do not normalise it — the mismatch
+	// should be surfaced rather than silently ignored.
 	local := []map[string]interface{}{
 		{"ColumnName": "name", "ColumnType": "string", "UserDefined": true},
 		{"ColumnName": "created", "ColumnType": "timestamp", "UserDefined": true},
@@ -297,11 +297,11 @@ func Test_TypeModifiers_BackendNormalized(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
-	if len(diff.Removed) != 0 {
-		t.Errorf("Expected 0 removals but got %d — type modifier caused false removal", len(diff.Removed))
+	if len(diff.Removed) != 2 {
+		t.Errorf("Expected 2 removals (mismatched types) but got %d", len(diff.Removed))
 	}
-	if len(diff.Added) != 0 {
-		t.Errorf("Expected 0 additions but got %d — type modifier caused false addition", len(diff.Added))
+	if len(diff.Added) != 2 {
+		t.Errorf("Expected 2 additions (mismatched types) but got %d", len(diff.Added))
 	}
 }
 


### PR DESCRIPTION
This PR fixes the issue of columns being dropped when ColumnType was invalid:

Previously IF the ColumnType of a column was NOT a valid ClearBlade platform type, THEN the column got dropped while pushing the schema. This affected collections but also custom columns in edge, device and user schemas. The schemas for these are defined by .json files where ColumnType is an item name in a JSON object.

The problem was encountered when calling **cb-cli push -<schema>...** with or without the **-piecemeal** flag. This PR addresses the issue when the **-piecemeal** flag is used. There is a corresponding ClearBlade PLATFORM PR to address the equivalent issue when the **-piecemeal** flag is NOT used.

The PR fixes the issue by throwing an error if the ColumnType does not match a valid ClearBlade type exactly.

Valid ClearBlade types are...
string
int
bool
timestamp
float
bigint
double
jsonb
blob
uuid