### PR TITLE
Use email for run as and euid

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -824,15 +824,17 @@ func writeService(name string, data map[string]interface{}) error {
 		}
 	}
 
-	// Store run_user as email so that pushing to a different system resolves
-	// to the correct user ID in the target system via the platform's ValidateCodeMeta.
-	if runUser, ok := data["run_user"].(string); ok && runUser != "" {
-		if email, err := getUserEmailByID(runUser); err != nil {
-			fmt.Printf("Warning - Could not resolve run_user %q to an email for service %q: %s\n", runUser, name, err)
-		} else if email != runUser {
-			data["run_user"] = email
-		} else {
-			fmt.Printf("Warning - Could not resolve run_user %q to an email for service %q. Either the user was not pulled previously OR the run_user is set to a developer account.\n", runUser, name)
+	// Store run_user and euid as email so that pushing to a different system
+	// resolves to the correct user ID in the target system via the platform's ValidateCodeMeta.
+	for _, field := range []string{"run_user", "euid"} {
+		if id, ok := data[field].(string); ok && id != "" {
+			if email, err := getUserEmailByID(id); err != nil {
+				fmt.Printf("Warning - Could not resolve %s %q to an email for service %q: %s\n", field, id, name, err)
+			} else if email != id {
+				data[field] = email
+			} else {
+				fmt.Printf("Warning - Could not resolve %s %q to an email for service %q. Either the user was not pulled previously OR the %s is set to a developer account.\n", field, id, name, field)
+			}
 		}
 	}
 

--- a/fs.go
+++ b/fs.go
@@ -824,6 +824,16 @@ func writeService(name string, data map[string]interface{}) error {
 		}
 	}
 
+	// Store run_user as email so that pushing to a different system resolves
+	// to the correct user ID in the target system via the platform's ValidateCodeMeta.
+	if runUser, ok := data["run_user"].(string); ok && runUser != "" {
+		if email, err := getUserEmailByID(runUser); err == nil {
+			data["run_user"] = email
+		} else {
+			fmt.Printf("Warning - Could not resolve run_user %q to an email: %s\n", runUser, err)
+		}
+	}
+
 	omitServiceFields(data)
 	return writeEntity(mySvcDir, name, data)
 }

--- a/fs.go
+++ b/fs.go
@@ -827,10 +827,12 @@ func writeService(name string, data map[string]interface{}) error {
 	// Store run_user as email so that pushing to a different system resolves
 	// to the correct user ID in the target system via the platform's ValidateCodeMeta.
 	if runUser, ok := data["run_user"].(string); ok && runUser != "" {
-		if email, err := getUserEmailByID(runUser); err == nil {
+		if email, err := getUserEmailByID(runUser); err != nil {
+			fmt.Printf("Warning - Could not resolve run_user %q to an email for service %q: %s\n", runUser, name, err)
+		} else if email != runUser {
 			data["run_user"] = email
 		} else {
-			fmt.Printf("Warning - Could not resolve run_user %q to an email: %s\n", runUser, err)
+			fmt.Printf("Warning - Could not resolve run_user %q to an email for service %q. Either the user was not pulled previously OR the run_user is set to a developer account.\n", runUser, name)
 		}
 	}
 

--- a/push.go
+++ b/push.go
@@ -1,8 +1,11 @@
 package cblib
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
+	"os"
+	"strings"
 
 	cb "github.com/clearblade/Go-SDK"
 	"github.com/clearblade/cblib/fs"
@@ -142,6 +145,26 @@ func doPush(cmd *SubCommand, client *cb.DevClient, args ...string) error {
 		return doLegacyPush(client, systemInfo)
 	}
 
+	if AllServices || AllAssets {
+		allSvcs, err := getServices()
+		if err != nil {
+			return err
+		}
+		names := make([]string, 0, len(allSvcs))
+		for _, svc := range allSvcs {
+			if name, ok := svc["name"].(string); ok {
+				names = append(names, name)
+			}
+		}
+		if err := warnIfServicesHaveUserIDRunUser(names); err != nil {
+			return err
+		}
+	} else if ServiceName != "" {
+		if err := warnIfServicesHaveUserIDRunUser([]string{ServiceName}); err != nil {
+			return err
+		}
+	}
+
 	return pushSystemZip(systemInfo, client, defaultZipOptions())
 }
 
@@ -197,6 +220,46 @@ func pushSystemZip(systemInfo *types.System_meta, client *cb.DevClient, options 
 
 	updateIdMap(r)
 	return r.Error()
+}
+
+// warnIfServicesHaveUserIDRunUser checks the services about to be pushed and
+// warns the user if any have run_user set to a user ID (non-email). A user ID
+// in run_user is unsafe when pushing to a different system because the ID will
+// not be valid there. If the user declines to continue, an error is returned.
+func warnIfServicesHaveUserIDRunUser(serviceNames []string) error {
+	if AutoApprove {
+		return nil
+	}
+	var affected []string
+	for _, name := range serviceNames {
+		svc, err := getService(name)
+		if err != nil {
+			continue
+		}
+		runUser, _ := svc["run_user"].(string)
+		if runUser != "" && !strings.Contains(runUser, "@") {
+			affected = append(affected, name)
+		}
+	}
+	if len(affected) == 0 {
+		return nil
+	}
+	fmt.Println("\nWarning: The following services have run_user set to a user ID rather than an email.")
+	fmt.Println("If pushing to a different system, the user ID may not be valid there.")
+	fmt.Println("Consider re-pulling from the source system first to resolve this.")
+	for _, name := range affected {
+		fmt.Printf("  - %s\n", name)
+	}
+	fmt.Print("\nPush anyway? (y / N = abort) ")
+	reader := bufio.NewReader(os.Stdin)
+	text, err := reader.ReadString('\n')
+	if err != nil {
+		return err
+	}
+	if strings.ToLower(strings.TrimSpace(text)) != "y" {
+		return fmt.Errorf("push aborted")
+	}
+	return nil
 }
 
 func updateIdMap(result *cb.SystemUploadChanges) {

--- a/push.go
+++ b/push.go
@@ -246,6 +246,9 @@ func warnIfServicesHaveUserIDRunUser(serviceNames []string) error {
 			continue
 		}
 		runUser, _ := svc["run_user"].(string)
+		if runUser == "" {
+			runUser, _ = svc["euid"].(string)
+		}
 		if runUser != "" && !strings.Contains(runUser, "@") {
 			affected = append(affected, name)
 		}

--- a/push.go
+++ b/push.go
@@ -215,11 +215,20 @@ func pushSystemZip(systemInfo *types.System_meta, client *cb.DevClient, options 
 	fmt.Println("Pushing changes")
 	r, err := client.UploadToSystem(systemInfo.Key, buffer)
 	if err != nil {
-		return err
+		return wrapRunUserError(err)
 	}
 
 	updateIdMap(r)
-	return r.Error()
+	return wrapRunUserError(r.Error())
+}
+
+// wrapRunUserError checks if an error from the platform is related to an
+// unresolvable run_user / euid and wraps it with a helpful hint.
+func wrapRunUserError(err error) error {
+	if err != nil && strings.Contains(err.Error(), "invalid run_as user") {
+		return fmt.Errorf("%w\nHint: the run_user / euid does not exist as a user or developer in the target system", err)
+	}
+	return err
 }
 
 // warnIfServicesHaveUserIDRunUser checks the services about to be pushed and

--- a/push.go
+++ b/push.go
@@ -215,20 +215,11 @@ func pushSystemZip(systemInfo *types.System_meta, client *cb.DevClient, options 
 	fmt.Println("Pushing changes")
 	r, err := client.UploadToSystem(systemInfo.Key, buffer)
 	if err != nil {
-		return wrapRunUserError(err)
+		return err
 	}
 
 	updateIdMap(r)
-	return wrapRunUserError(r.Error())
-}
-
-// wrapRunUserError checks if an error from the platform is related to an
-// unresolvable run_user / euid and wraps it with a helpful hint.
-func wrapRunUserError(err error) error {
-	if err != nil && strings.Contains(err.Error(), "invalid run_as user") {
-		return fmt.Errorf("%w\nHint: the run_user / euid does not exist as a user or developer in the target system", err)
-	}
-	return err
+	return r.Error()
 }
 
 // warnIfServicesHaveUserIDRunUser checks the services about to be pushed and

--- a/push_legacy.go
+++ b/push_legacy.go
@@ -88,6 +88,21 @@ func doLegacyPush(client *cb.DevClient, systemInfo *types.System_meta) error {
 		opts := cbfs.NewZipOptions(&mapper{})
 		opts.AllServices = AllServices || AllAssets
 		opts.AllLibraries = AllLibraries || AllAssets
+		if AllServices || AllAssets {
+			allSvcs, err := getServices()
+			if err != nil {
+				return err
+			}
+			names := make([]string, 0, len(allSvcs))
+			for _, svc := range allSvcs {
+				if name, ok := svc["name"].(string); ok {
+					names = append(names, name)
+				}
+			}
+			if err := warnIfServicesHaveUserIDRunUser(names); err != nil {
+				return err
+			}
+		}
 		if err := pushCode(systemInfo, client, opts); err != nil {
 			return err
 		}
@@ -102,6 +117,9 @@ func doLegacyPush(client *cb.DevClient, systemInfo *types.System_meta) error {
 
 	if ServiceName != "" {
 		didSomething = true
+		if err := warnIfServicesHaveUserIDRunUser([]string{ServiceName}); err != nil {
+			return err
+		}
 		if err := pushOneService(systemInfo, client, ServiceName); err != nil {
 			return err
 		}
@@ -372,6 +390,7 @@ func doLegacyPush(client *cb.DevClient, systemInfo *types.System_meta) error {
 
 	return nil
 }
+
 
 func pushOneService(systemInfo *types.System_meta, client *cb.DevClient, name string) error {
 	fmt.Printf("Pushing service %+s\n", name)

--- a/push_legacy.go
+++ b/push_legacy.go
@@ -2095,7 +2095,7 @@ func updateService(systemKey, name string, service map[string]interface{}, clien
 		extra := getServiceBody(service)
 		_, err := client.UpdateServiceWithBody(systemKey, name, svcCode, extra)
 		if err != nil {
-			return err
+			return wrapRunUserError(err)
 		}
 
 	}

--- a/push_legacy.go
+++ b/push_legacy.go
@@ -2095,7 +2095,7 @@ func updateService(systemKey, name string, service map[string]interface{}, clien
 		extra := getServiceBody(service)
 		_, err := client.UpdateServiceWithBody(systemKey, name, svcCode, extra)
 		if err != nil {
-			return wrapRunUserError(err)
+			return err
 		}
 
 	}


### PR DESCRIPTION
Changes in this PR:
1. When pulling from a system, set the run_as user and euid for services to email addresses instead of user IDs.
2. If a resolution to email is not possible warn that the user may not have been pulled OR it is actually a DEVELOPER.
3. When pushing, throw warning if the run_as user / euid email was not found.
4. When pushing systems with services where run_user / euid are user IDs instead of emails, show a warning and allow the user to choose to continue anyway.